### PR TITLE
Fixes advanced sorting with modded installs, including Mk2 Expansion and SystemHeat.

### DIFF
--- a/Source/VABOrganizer/AdvancedSorting.cs
+++ b/Source/VABOrganizer/AdvancedSorting.cs
@@ -174,7 +174,7 @@ namespace VABOrganizer
         if (curMode != uiSorterBase.sortingButtonStates[5])
         {
           Utils.Log($"[Advanced Sorting] In a non-custom mode, clicking button 5");
-          // Just fake click the button
+          // ClickButton invokes SortingCallback synchronously, so select the requested sorter before entering custom mode.
           uiSorterBase.ClickButton(5);
           CurrentAdvancedSort = newType;
           return;

--- a/Source/VABOrganizer/AvailablePartData.cs
+++ b/Source/VABOrganizer/AvailablePartData.cs
@@ -11,17 +11,11 @@ namespace VABOrganizer
     public Dictionary<string, AvailablePartData> PartData;
     public static List<CustomSortVariable> ConfigVariables = new List<CustomSortVariable>();
 
-    // TODO: Remove the per-sort coverage diagnostics after the modded-install
-    // failure is understood and verified; they are intentionally one-shot.
-    private readonly HashSet<string> loggedSortCoverage = new HashSet<string>();
-
     public static AdvancedSortingDataStore Instance;
 
     void Awake()
     {
       Instance = this;
-      GameObject.DontDestroyOnLoad(gameObject);
-      Utils.LogWarning("[AdvancedSortingDataStore]: Data store marked persistent");
     }
 
     void Start()
@@ -58,11 +52,6 @@ namespace VABOrganizer
     void OnDestroy()
     {
       GameEvents.OnPartLoaderLoaded.Remove(OnPartLoaderLoaded);
-      Utils.LogWarning($"[AdvancedSortingDataStore]: Data store destroyed with {PartData?.Count ?? 0} indexed parts");
-      if (ReferenceEquals(Instance, this))
-      {
-        Instance = null;
-      }
     }
 
     public void OnPartLoaderLoaded()
@@ -70,58 +59,33 @@ namespace VABOrganizer
       PartData = new Dictionary<string, AvailablePartData>();
       var watch = System.Diagnostics.Stopwatch.StartNew();
       Utils.Log($"[AdvancedSortingDataStore]: Starting part data parse");
-      int duplicateParts = 0;
-      int failedParts = 0;
-      int partsWithoutSortData = 0;
-      int sortValueCount = 0;
       foreach (AvailablePart p in PartLoader.Instance.loadedParts)
       {
-        if (PartData.ContainsKey(p.name))
+        if (p == null || string.IsNullOrEmpty(p.name))
         {
-          duplicateParts++;
-          Utils.LogWarning($"[AdvancedSortingDataStore]: Duplicate loaded part name '{p.name}' ({p.title}); keeping the first entry");
+          Utils.LogWarning("[AdvancedSortingDataStore]: Loaded part has no name, skipping");
           continue;
         }
 
         try
         {
-          AvailablePartData partData = new AvailablePartData(p);
-          PartData.Add(p.name, partData);
-          sortValueCount += partData.DataEntryCount;
-          if (partData.DataEntryCount == 0)
+          if (PartData.ContainsKey(p.name))
           {
-            partsWithoutSortData++;
+            Utils.LogWarning($"[AdvancedSortingDataStore]: Duplicate loaded part name '{p.name}' ({p.title}); keeping the first entry");
+            continue;
           }
+
+          PartData.Add(p.name, new AvailablePartData(p));
         }
         catch (Exception e)
         {
-          failedParts++;
           Utils.LogError($"[AdvancedSortingDataStore]: Failed to parse part '{p.name}' ({p.title}): {e}");
         }
       }
       watch.Stop();
       /// TODO: 7 ms for stock + NFT on Chris' garbage laptop is fine, may need to be optimized later
-      Utils.LogWarning($"[AdvancedSortingDataStore]: Parsed {PartData.Count}/{PartLoader.Instance.loadedParts.Count} unique loaded parts in {watch.ElapsedMilliseconds} ms; duplicates={duplicateParts}, failures={failedParts}, partsWithoutSortData={partsWithoutSortData}, sortValues={sortValueCount}");
+      Utils.Log($"[AdvancedSortingDataStore]: Parsed config data in {watch.ElapsedMilliseconds} ms");
 
-    }
-
-    public void LogSortCoverage(string sortKey)
-    {
-      if (PartData == null || string.IsNullOrEmpty(sortKey) || !loggedSortCoverage.Add(sortKey))
-      {
-        return;
-      }
-
-      int partsWithValue = 0;
-      foreach (AvailablePartData partData in PartData.Values)
-      {
-        if (partData.HasData(sortKey))
-        {
-          partsWithValue++;
-        }
-      }
-
-      Utils.LogWarning($"[AdvancedSortingDataStore]: Sort key '{sortKey}' has explicit values for {partsWithValue}/{PartData.Count} indexed parts; remaining parts use the original zero fallback");
     }
 
   }
@@ -130,16 +94,6 @@ namespace VABOrganizer
   {
     Dictionary<string, float> dataEntries;
     AvailablePart basePart;
-
-    public int DataEntryCount
-    {
-      get { return dataEntries.Count; }
-    }
-
-    public bool HasData(string index)
-    {
-      return dataEntries.ContainsKey(index);
-    }
 
     public float GetData(string index)
     {

--- a/Source/VABOrganizer/AvailablePartData.cs
+++ b/Source/VABOrganizer/AvailablePartData.cs
@@ -21,28 +21,31 @@ namespace VABOrganizer
     void Start()
     {
       ConfigNode[] variableRoot = GameDatabase.Instance.GetConfigNodes(Settings.ORGANIZER_VARIABLE_ROOT_NODE_NAME);
-      if (variableRoot.Length > 0)
+      List<ConfigNode> variableNodes = new List<ConfigNode>();
+      foreach (ConfigNode rootNode in variableRoot)
+      {
+        variableNodes.AddRange(rootNode.GetNodes(Settings.ORGANIZER_VARIABLE_NODE_NAME));
+      }
+      variableNodes.AddRange(GameDatabase.Instance.GetConfigNodes(Settings.ORGANIZER_VARIABLE_NODE_NAME));
+
+      if (variableNodes.Count > 0)
       {
         ConfigVariables = new List<CustomSortVariable>();
         Utils.Log($"[AdvancedSortingDataStore]: Loading variable definitions");
 
-        foreach (ConfigNode rootNode in variableRoot)
+        foreach (ConfigNode varNode in variableNodes)
         {
-          ConfigNode[] variableNodes = rootNode.GetNodes(Settings.ORGANIZER_VARIABLE_NODE_NAME);
-          foreach (ConfigNode varNode in variableNodes)
+          CustomSortVariable data = new CustomSortVariable(varNode);
+          if (!ConfigVariables.Contains(data))
           {
-            CustomSortVariable data = new CustomSortVariable(varNode);
-            if (!ConfigVariables.Contains(data))
-            {
-              ConfigVariables.Add(data);
-            }
-            else
-            {
-              Utils.LogWarning($"[AdvancedSortingDataStore]: Multiple {Settings.ORGANIZER_VARIABLE_NODE_NAME} with the same name ({data.Name}) found, skipping others");
-            }
+            ConfigVariables.Add(data);
           }
-          Utils.Log($"[AdvancedSortingDataStore]: Loaded {ConfigVariables.Count} sorting variable definitions");
+          else
+          {
+            Utils.LogWarning($"[AdvancedSortingDataStore]: Multiple {Settings.ORGANIZER_VARIABLE_NODE_NAME} with the same name ({data.Name}) found, skipping others");
+          }
         }
+        Utils.Log($"[AdvancedSortingDataStore]: Loaded {ConfigVariables.Count} sorting variable definitions");
       }
 
 

--- a/Source/VABOrganizer/AvailablePartData.cs
+++ b/Source/VABOrganizer/AvailablePartData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace VABOrganizer
@@ -10,11 +11,17 @@ namespace VABOrganizer
     public Dictionary<string, AvailablePartData> PartData;
     public static List<CustomSortVariable> ConfigVariables = new List<CustomSortVariable>();
 
+    // TODO: Remove the per-sort coverage diagnostics after the modded-install
+    // failure is understood and verified; they are intentionally one-shot.
+    private readonly HashSet<string> loggedSortCoverage = new HashSet<string>();
+
     public static AdvancedSortingDataStore Instance;
 
     void Awake()
     {
       Instance = this;
+      GameObject.DontDestroyOnLoad(gameObject);
+      Utils.LogWarning("[AdvancedSortingDataStore]: Data store marked persistent");
     }
 
     void Start()
@@ -51,6 +58,11 @@ namespace VABOrganizer
     void OnDestroy()
     {
       GameEvents.OnPartLoaderLoaded.Remove(OnPartLoaderLoaded);
+      Utils.LogWarning($"[AdvancedSortingDataStore]: Data store destroyed with {PartData?.Count ?? 0} indexed parts");
+      if (ReferenceEquals(Instance, this))
+      {
+        Instance = null;
+      }
     }
 
     public void OnPartLoaderLoaded()
@@ -58,14 +70,58 @@ namespace VABOrganizer
       PartData = new Dictionary<string, AvailablePartData>();
       var watch = System.Diagnostics.Stopwatch.StartNew();
       Utils.Log($"[AdvancedSortingDataStore]: Starting part data parse");
+      int duplicateParts = 0;
+      int failedParts = 0;
+      int partsWithoutSortData = 0;
+      int sortValueCount = 0;
       foreach (AvailablePart p in PartLoader.Instance.loadedParts)
       {
-        PartData.Add(p.name, new AvailablePartData(p));
+        if (PartData.ContainsKey(p.name))
+        {
+          duplicateParts++;
+          Utils.LogWarning($"[AdvancedSortingDataStore]: Duplicate loaded part name '{p.name}' ({p.title}); keeping the first entry");
+          continue;
+        }
+
+        try
+        {
+          AvailablePartData partData = new AvailablePartData(p);
+          PartData.Add(p.name, partData);
+          sortValueCount += partData.DataEntryCount;
+          if (partData.DataEntryCount == 0)
+          {
+            partsWithoutSortData++;
+          }
+        }
+        catch (Exception e)
+        {
+          failedParts++;
+          Utils.LogError($"[AdvancedSortingDataStore]: Failed to parse part '{p.name}' ({p.title}): {e}");
+        }
       }
       watch.Stop();
       /// TODO: 7 ms for stock + NFT on Chris' garbage laptop is fine, may need to be optimized later
-      Utils.Log($"[AdvancedSortingDataStore]: Parsed config data in {watch.ElapsedMilliseconds} ms");
+      Utils.LogWarning($"[AdvancedSortingDataStore]: Parsed {PartData.Count}/{PartLoader.Instance.loadedParts.Count} unique loaded parts in {watch.ElapsedMilliseconds} ms; duplicates={duplicateParts}, failures={failedParts}, partsWithoutSortData={partsWithoutSortData}, sortValues={sortValueCount}");
 
+    }
+
+    public void LogSortCoverage(string sortKey)
+    {
+      if (PartData == null || string.IsNullOrEmpty(sortKey) || !loggedSortCoverage.Add(sortKey))
+      {
+        return;
+      }
+
+      int partsWithValue = 0;
+      foreach (AvailablePartData partData in PartData.Values)
+      {
+        if (partData.HasData(sortKey))
+        {
+          partsWithValue++;
+        }
+      }
+
+      Utils.LogWarning($"[AdvancedSortingDataStore]: Sort key '{sortKey}' has explicit values for {partsWithValue}/{PartData.Count} indexed parts; remaining parts use the original zero fallback");
     }
 
   }
@@ -74,6 +130,16 @@ namespace VABOrganizer
   {
     Dictionary<string, float> dataEntries;
     AvailablePart basePart;
+
+    public int DataEntryCount
+    {
+      get { return dataEntries.Count; }
+    }
+
+    public bool HasData(string index)
+    {
+      return dataEntries.ContainsKey(index);
+    }
 
     public float GetData(string index)
     {

--- a/Source/VABOrganizer/Harmony/EditorPartList.cs
+++ b/Source/VABOrganizer/Harmony/EditorPartList.cs
@@ -1,4 +1,6 @@
-﻿using KSP.UI.Screens;
+﻿using System;
+using System.Collections.Generic;
+using KSP.UI.Screens;
 using HarmonyLib;
 
 namespace VABOrganizer.HarmonyPatches
@@ -6,6 +8,11 @@ namespace VABOrganizer.HarmonyPatches
   [HarmonyPatch(typeof(EditorPartList))]
   internal class PatchEditorPartList
   {
+    // TODO: Reassess these one-shot diagnostics before publishing once the
+    // remaining modded-install failures have been identified.
+    private static readonly HashSet<string> MissingPartDataWarnings = new HashSet<string>();
+    private static bool dataStoreUnavailableWarningLogged;
+
     /// <summary>
     /// Patch the sorter to add the Bulkhead sorter
     /// </summary>
@@ -30,11 +37,59 @@ namespace VABOrganizer.HarmonyPatches
       {
         if (AdvancedSorting.CurrentAdvancedSort != null)
         {
+          string sortKey = AdvancedSorting.CurrentAdvancedSort.Sorter;
+          if (!ReferenceEquals(AdvancedSortingDataStore.Instance, null))
+          {
+            AdvancedSortingDataStore.Instance.LogSortCoverage(sortKey);
+          }
           partSortProperty.SetValue(__instance,
             new RUIutils.FuncComparer<AvailablePart>((AvailablePart r1, AvailablePart r2) =>
-            RUIutils.SortAscDescPrimarySecondary(asc, AdvancedSortingDataStore.Instance.PartData[r1.name].GetData(AdvancedSorting.CurrentAdvancedSort.Sorter).CompareTo(AdvancedSortingDataStore.Instance.PartData[r2.name].GetData(AdvancedSorting.CurrentAdvancedSort.Sorter)), r1.title.CompareTo(r2.title))));
+            RUIutils.SortAscDescPrimarySecondary(asc, CompareAdvancedSortValues(r1, r2, sortKey), string.Compare(r1.title, r2.title, StringComparison.Ordinal))));
         }
       }
+      return true;
+    }
+
+    private static int CompareAdvancedSortValues(AvailablePart first, AvailablePart second, string sortKey)
+    {
+      bool hasFirst = TryGetPartData(first, out AvailablePartData firstData);
+      bool hasSecond = TryGetPartData(second, out AvailablePartData secondData);
+
+      if (hasFirst && hasSecond)
+      {
+        return firstData.GetData(sortKey).CompareTo(secondData.GetData(sortKey));
+      }
+
+      return hasFirst == hasSecond ? 0 : hasFirst ? 1 : -1;
+    }
+
+    private static bool TryGetPartData(AvailablePart part, out AvailablePartData partData)
+    {
+      partData = null;
+      AdvancedSortingDataStore store = AdvancedSortingDataStore.Instance;
+      // Unity objects compare equal to null after destruction even while their
+      // managed fields remain reachable. ReferenceEquals avoids misclassifying
+      // that state as an unpopulated data store during diagnostics/fallback.
+      if (ReferenceEquals(store, null) || store.PartData == null)
+      {
+        if (!dataStoreUnavailableWarningLogged)
+        {
+          dataStoreUnavailableWarningLogged = true;
+          Utils.LogError("[Advanced Sorting]: Part data store is unavailable during comparison");
+        }
+        return false;
+      }
+
+      if (part == null || string.IsNullOrEmpty(part.name) || !store.PartData.TryGetValue(part.name, out partData))
+      {
+        string partName = part == null ? "<null>" : part.name ?? "<unnamed>";
+        if (MissingPartDataWarnings.Add(partName))
+        {
+          Utils.LogWarning($"[Advanced Sorting]: No parsed sort data for editor part '{partName}'; using title ordering for comparisons involving it");
+        }
+        return false;
+      }
+
       return true;
     }
     /// <summary>

--- a/Source/VABOrganizer/Harmony/EditorPartList.cs
+++ b/Source/VABOrganizer/Harmony/EditorPartList.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using KSP.UI.Screens;
+﻿using KSP.UI.Screens;
 using HarmonyLib;
 
 namespace VABOrganizer.HarmonyPatches
@@ -8,11 +6,6 @@ namespace VABOrganizer.HarmonyPatches
   [HarmonyPatch(typeof(EditorPartList))]
   internal class PatchEditorPartList
   {
-    // TODO: Reassess these one-shot diagnostics before publishing once the
-    // remaining modded-install failures have been identified.
-    private static readonly HashSet<string> MissingPartDataWarnings = new HashSet<string>();
-    private static bool dataStoreUnavailableWarningLogged;
-
     /// <summary>
     /// Patch the sorter to add the Bulkhead sorter
     /// </summary>
@@ -38,22 +31,23 @@ namespace VABOrganizer.HarmonyPatches
         if (AdvancedSorting.CurrentAdvancedSort != null)
         {
           string sortKey = AdvancedSorting.CurrentAdvancedSort.Sorter;
-          if (!ReferenceEquals(AdvancedSortingDataStore.Instance, null))
-          {
-            AdvancedSortingDataStore.Instance.LogSortCoverage(sortKey);
-          }
           partSortProperty.SetValue(__instance,
             new RUIutils.FuncComparer<AvailablePart>((AvailablePart r1, AvailablePart r2) =>
-            RUIutils.SortAscDescPrimarySecondary(asc, CompareAdvancedSortValues(r1, r2, sortKey), string.Compare(r1.title, r2.title, StringComparison.Ordinal))));
+            RUIutils.SortAscDescPrimarySecondary(asc, CompareAdvancedSortValues(r1, r2, sortKey), r1.title.CompareTo(r2.title))));
         }
       }
       return true;
     }
 
+    /// <summary>
+    /// Compare parsed advanced-sort values without allowing an unparseable or
+    /// dynamically added part to break sorting for the entire editor list.
+    /// </summary>
     private static int CompareAdvancedSortValues(AvailablePart first, AvailablePart second, string sortKey)
     {
-      bool hasFirst = TryGetPartData(first, out AvailablePartData firstData);
-      bool hasSecond = TryGetPartData(second, out AvailablePartData secondData);
+      var partData = AdvancedSortingDataStore.Instance.PartData;
+      bool hasFirst = partData.TryGetValue(first.name, out AvailablePartData firstData);
+      bool hasSecond = partData.TryGetValue(second.name, out AvailablePartData secondData);
 
       if (hasFirst && hasSecond)
       {
@@ -61,36 +55,6 @@ namespace VABOrganizer.HarmonyPatches
       }
 
       return hasFirst == hasSecond ? 0 : hasFirst ? 1 : -1;
-    }
-
-    private static bool TryGetPartData(AvailablePart part, out AvailablePartData partData)
-    {
-      partData = null;
-      AdvancedSortingDataStore store = AdvancedSortingDataStore.Instance;
-      // Unity objects compare equal to null after destruction even while their
-      // managed fields remain reachable. ReferenceEquals avoids misclassifying
-      // that state as an unpopulated data store during diagnostics/fallback.
-      if (ReferenceEquals(store, null) || store.PartData == null)
-      {
-        if (!dataStoreUnavailableWarningLogged)
-        {
-          dataStoreUnavailableWarningLogged = true;
-          Utils.LogError("[Advanced Sorting]: Part data store is unavailable during comparison");
-        }
-        return false;
-      }
-
-      if (part == null || string.IsNullOrEmpty(part.name) || !store.PartData.TryGetValue(part.name, out partData))
-      {
-        string partName = part == null ? "<null>" : part.name ?? "<unnamed>";
-        if (MissingPartDataWarnings.Add(partName))
-        {
-          Utils.LogWarning($"[Advanced Sorting]: No parsed sort data for editor part '{partName}'; using title ordering for comparisons involving it");
-        }
-        return false;
-      }
-
-      return true;
     }
     /// <summary>
     /// Patch the part icon update to assign icons to the right categories

--- a/Source/VABOrganizer/Utils.cs
+++ b/Source/VABOrganizer/Utils.cs
@@ -38,7 +38,7 @@ namespace VABOrganizer
       }
       catch (NullReferenceException e)
       {
-        Debug.LogError($"Couldn't find {name} in children of {parent.name}");
+        Debug.LogError($"Couldn't find {name} in children of {parent.name}: {e}");
       }
       return result;
     }


### PR DESCRIPTION

- Handles duplicate and malformed part entries without breaking the sort index
- Supports wrapped and standalone sorting-variable configurations
- Resolves a minor compiler warning

AFAIK: 
- Fixes #30
- Fixes #31
- Related to #33